### PR TITLE
Получение заметок определенного типа

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -167,14 +167,71 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "202": {
-                        "description": "Accepted",
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.NoteTypeResponse"
                             }
                         }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/spaces/{id}/notes/{type}": {
+            "get": {
+                "description": "Получить все заметки определенного типа: текстовые, фото, етс",
+                "summary": "Получить все заметки одного типа",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID пространства",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "тип заметки: текст, фото, етс",
+                        "name": "type",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GetNote"
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
                     },
                     "400": {
                         "description": "Невалидный запрос",
@@ -202,6 +259,10 @@ const docTemplate = `{
         "model.CreateNoteRequest": {
             "type": "object",
             "properties": {
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "type": "string"
+                },
                 "space_id": {
                     "description": "айди пространства, куда сохранить заметку",
                     "type": "string"
@@ -231,6 +292,14 @@ const docTemplate = `{
                     "description": "дата создания заметки в часовом поясе пользователя в unix",
                     "type": "string"
                 },
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/sql.NullString"
+                        }
+                    ]
+                },
                 "id": {
                     "type": "string"
                 },
@@ -256,6 +325,10 @@ const docTemplate = `{
             "properties": {
                 "created": {
                     "description": "дата создания заметки в часовом поясе пользователя в unix",
+                    "type": "string"
+                },
+                "file": {
+                    "description": "название файла в Minio (если есть)",
                     "type": "string"
                 },
                 "id": {
@@ -342,6 +415,10 @@ const docTemplate = `{
         "model.UpdateNoteRequest": {
             "type": "object",
             "properties": {
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "type": "string"
+                },
                 "id": {
                     "description": "айди заметки",
                     "type": "string"
@@ -375,6 +452,18 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "sql.NullString": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "Valid is true if String is not NULL",
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -116,15 +116,6 @@ const docTemplate = `{
             "get": {
                 "description": "Запрос на получение всех заметок из личного пространства пользователя",
                 "summary": "Запрос на получение всех заметок",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "ID пространства",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -149,6 +140,50 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Пространства не существует"
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/spaces/{id}/notes/types": {
+            "get": {
+                "description": "Получить список всех типов заметок и их количество",
+                "summary": "Получить все типы заметок",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID пространства",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.NoteTypeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "500": {
                         "description": "Внутренняя ошибка",
@@ -269,6 +304,17 @@ const docTemplate = `{
                 "TextNoteType",
                 "PhotoNoteType"
             ]
+        },
+        "model.NoteTypeResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/model.NoteType"
+                }
+            }
         },
         "model.Space": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -158,14 +158,71 @@
                     }
                 ],
                 "responses": {
-                    "202": {
-                        "description": "Accepted",
+                    "200": {
+                        "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/model.NoteTypeResponse"
                             }
                         }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/spaces/{id}/notes/{type}": {
+            "get": {
+                "description": "Получить все заметки определенного типа: текстовые, фото, етс",
+                "summary": "Получить все заметки одного типа",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID пространства",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "тип заметки: текст, фото, етс",
+                        "name": "type",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GetNote"
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
                     },
                     "400": {
                         "description": "Невалидный запрос",
@@ -193,6 +250,10 @@
         "model.CreateNoteRequest": {
             "type": "object",
             "properties": {
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "type": "string"
+                },
                 "space_id": {
                     "description": "айди пространства, куда сохранить заметку",
                     "type": "string"
@@ -222,6 +283,14 @@
                     "description": "дата создания заметки в часовом поясе пользователя в unix",
                     "type": "string"
                 },
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/sql.NullString"
+                        }
+                    ]
+                },
                 "id": {
                     "type": "string"
                 },
@@ -247,6 +316,10 @@
             "properties": {
                 "created": {
                     "description": "дата создания заметки в часовом поясе пользователя в unix",
+                    "type": "string"
+                },
+                "file": {
+                    "description": "название файла в Minio (если есть)",
                     "type": "string"
                 },
                 "id": {
@@ -333,6 +406,10 @@
         "model.UpdateNoteRequest": {
             "type": "object",
             "properties": {
+                "file": {
+                    "description": "название файла в Minio (если есть)",
+                    "type": "string"
+                },
                 "id": {
                     "description": "айди заметки",
                     "type": "string"
@@ -366,6 +443,18 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "sql.NullString": {
+            "type": "object",
+            "properties": {
+                "string": {
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "Valid is true if String is not NULL",
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -107,15 +107,6 @@
             "get": {
                 "description": "Запрос на получение всех заметок из личного пространства пользователя",
                 "summary": "Запрос на получение всех заметок",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "ID пространства",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -140,6 +131,50 @@
                     },
                     "404": {
                         "description": "Пространства не существует"
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/spaces/{id}/notes/types": {
+            "get": {
+                "description": "Получить список всех типов заметок и их количество",
+                "summary": "Получить все типы заметок",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID пространства",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.NoteTypeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "500": {
                         "description": "Внутренняя ошибка",
@@ -260,6 +295,17 @@
                 "TextNoteType",
                 "PhotoNoteType"
             ]
+        },
+        "model.NoteTypeResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/model.NoteType"
+                }
+            }
         },
         "model.Space": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,9 @@
 definitions:
   model.CreateNoteRequest:
     properties:
+      file:
+        description: название файла в Minio (если есть)
+        type: string
       space_id:
         description: айди пространства, куда сохранить заметку
         type: string
@@ -20,6 +23,10 @@ definitions:
       created:
         description: дата создания заметки в часовом поясе пользователя в unix
         type: string
+      file:
+        allOf:
+        - $ref: '#/definitions/sql.NullString'
+        description: название файла в Minio (если есть)
       id:
         type: string
       last_edit:
@@ -37,6 +44,9 @@ definitions:
     properties:
       created:
         description: дата создания заметки в часовом поясе пользователя в unix
+        type: string
+      file:
+        description: название файла в Minio (если есть)
         type: string
       id:
         type: string
@@ -91,6 +101,9 @@ definitions:
     type: object
   model.UpdateNoteRequest:
     properties:
+      file:
+        description: название файла в Minio (если есть)
+        type: string
       id:
         description: айди заметки
         type: string
@@ -114,6 +127,14 @@ definitions:
         type: string
       username:
         type: string
+    type: object
+  sql.NullString:
+    properties:
+      string:
+        type: string
+      valid:
+        description: Valid is true if String is not NULL
+        type: boolean
     type: object
   sql.NullTime:
     properties:
@@ -163,6 +184,42 @@ paths:
               type: string
             type: object
       summary: Запрос на получение всех заметок
+  /spaces/{id}/notes/{type}:
+    get:
+      description: 'Получить все заметки определенного типа: текстовые, фото, етс'
+      parameters:
+      - description: ID пространства
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'тип заметки: текст, фото, етс'
+        in: path
+        name: type
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GetNote'
+            type: array
+        "204":
+          description: Нет заметок
+        "400":
+          description: Невалидный запрос
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Внутренняя ошибка
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Получить все заметки одного типа
   /spaces/{id}/notes/types:
     get:
       description: Получить список всех типов заметок и их количество
@@ -173,12 +230,14 @@ paths:
         required: true
         type: string
       responses:
-        "202":
-          description: Accepted
+        "200":
+          description: OK
           schema:
             items:
               $ref: '#/definitions/model.NoteTypeResponse'
             type: array
+        "204":
+          description: Нет заметок
         "400":
           description: Невалидный запрос
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -66,6 +66,13 @@ definitions:
     x-enum-varnames:
     - TextNoteType
     - PhotoNoteType
+  model.NoteTypeResponse:
+    properties:
+      count:
+        type: integer
+      type:
+        $ref: '#/definitions/model.NoteType'
+    type: object
   model.Space:
     properties:
       created:
@@ -132,12 +139,6 @@ paths:
   /spaces/{id}/notes:
     get:
       description: Запрос на получение всех заметок из личного пространства пользователя
-      parameters:
-      - description: ID пространства
-        in: path
-        name: id
-        required: true
-        type: integer
       responses:
         "200":
           description: OK
@@ -162,6 +163,35 @@ paths:
               type: string
             type: object
       summary: Запрос на получение всех заметок
+  /spaces/{id}/notes/types:
+    get:
+      description: Получить список всех типов заметок и их количество
+      parameters:
+      - description: ID пространства
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            items:
+              $ref: '#/definitions/model.NoteTypeResponse'
+            type: array
+        "400":
+          description: Невалидный запрос
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Внутренняя ошибка
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Получить все типы заметок
   /spaces/notes/create:
     post:
       description: Запрос на создание заметки с текстом. Создается в указанном пространстве

--- a/internal/errors/space.go
+++ b/internal/errors/space.go
@@ -11,4 +11,6 @@ var (
 	ErrSpaceNotExists = errors.New("space does not exist")
 	// ошибка о том, что пользователь не состоит в пространстве
 	ErrUserNotBelongsSpace = errors.New("user not in space")
+	// ошибка о том, что не найдены заметки указанного типа
+	ErrNoNotesFoundByType = errors.New("no notes found by this type")
 )

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -50,6 +50,7 @@ type CreateNoteRequest struct {
 	SpaceID uuid.UUID `json:"space_id"` // айди пространства, куда сохранить заметку
 	Text    string    `json:"text"`     // текст заметки
 	Type    NoteType  `json:"type"`     // тип заметки: текстовая, фото, видео, етс
+	File    string    `json:"file"`     // название файла в Minio (если есть)
 }
 
 func (s *CreateNoteRequest) Validate() error {
@@ -82,6 +83,7 @@ type Note struct {
 	Created  time.Time    `json:"created"` // дата создания заметки в часовом поясе пользователя в unix
 	LastEdit sql.NullTime `json:"last_edit"`
 	Type     NoteType     `json:"type"` // тип заметки: текстовая, фото, видео, етс
+	File     string       `json:"file"` // название файла в Minio (если есть)
 }
 
 var ErrSpaceIsNil = fmt.Errorf("field `Space` is nil")
@@ -117,13 +119,14 @@ func (s *Note) Validate() error {
 // структура для ответа на запрос всех заметок пространства в кратком режиме.
 // У этой структуры поля пользователь и пространство заменены на айди
 type GetNote struct {
-	ID       uuid.UUID    `json:"id"`
-	UserID   int          `json:"user_id"`
-	Text     string       `json:"text"`
-	SpaceID  uuid.UUID    `json:"space_id"`
-	Created  time.Time    `json:"created"` // дата создания заметки в часовом поясе пользователя в unix
-	LastEdit sql.NullTime `json:"last_edit"`
-	Type     NoteType     `json:"type"`
+	ID       uuid.UUID      `json:"id"`
+	UserID   int            `json:"user_id"`
+	Text     string         `json:"text"`
+	SpaceID  uuid.UUID      `json:"space_id"`
+	Created  time.Time      `json:"created"` // дата создания заметки в часовом поясе пользователя в unix
+	LastEdit sql.NullTime   `json:"last_edit"`
+	Type     NoteType       `json:"type"`
+	File     sql.NullString `json:"file"` // название файла в Minio (если есть)
 }
 
 func (s *GetNote) Validate() error {
@@ -166,6 +169,7 @@ type UpdateNoteRequest struct {
 	UserID  int64     `json:"user_id"`
 	NoteID  uuid.UUID `json:"id"`   // айди заметки
 	Text    string    `json:"text"` // новый текст
+	File    string    `json:"file"` // название файла в Minio (если есть)
 }
 
 func (s *UpdateNoteRequest) Validate() error {

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -46,6 +46,7 @@ func runTestServer(server *server) (*echo.Echo, error) {
 	spaces.POST("/notes/create", server.createNote, server.validateNoteRequest)
 	spaces.PATCH("/notes/update", server.updateNote, server.validateNoteRequest)
 	spaces.GET("/:id/notes/types", server.getNoteTypes)
+	spaces.GET("/:id/notes/:type", server.getNotesByType)
 
 	return e, nil
 }

--- a/internal/server/notes.go
+++ b/internal/server/notes.go
@@ -73,7 +73,7 @@ func errorsIn(target error, errs []error) bool {
 
 //		@Summary		Запрос на получение всех заметок
 //		@Description	Запрос на получение всех заметок из личного пространства пользователя
-//	 @Param        id   path      int  true  "ID пространства"
+//	    @Param        id   path      uuid  true  "ID пространства"
 //		@Success		200 {object}    []model.Note
 //		@Success		200 {object}    []model.GetNote
 //		@Success		204                               "В пространстве отсутствют заметки"
@@ -209,6 +209,15 @@ func (s *server) updateNote(c echo.Context) error {
 	return c.JSON(http.StatusAccepted, map[string]string{"request_id": req.ID.String()})
 }
 
+//	@Summary		Получить все типы заметок
+//	@Description	Получить список всех типов заметок и их количество
+//	@Param          id   path      string  true  "ID пространства"//
+//	@Success		202 {object}    []model.NoteTypeResponse   массив с типами заметок и их количеством
+//	@Failure		400	{object}	map[string]string "Невалидный запрос"
+//	@Failure		500	{object}	map[string]string "Внутренняя ошибка"
+//	@Router			/spaces/{id}/notes/types [get]
+//
+// ручка для получения типов заметок
 func (s *server) getNoteTypes(c echo.Context) error {
 	spaceIDStr := c.Param("id")
 
@@ -227,4 +236,8 @@ func (s *server) getNoteTypes(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, types)
+}
+
+func (s *server) getNotesByType(c echo.Context) error {
+	return nil
 }

--- a/internal/server/notes.go
+++ b/internal/server/notes.go
@@ -212,7 +212,8 @@ func (s *server) updateNote(c echo.Context) error {
 //	@Summary		Получить все типы заметок
 //	@Description	Получить список всех типов заметок и их количество
 //	@Param          id   path      string  true  "ID пространства"//
-//	@Success		202 {object}    []model.NoteTypeResponse   массив с типами заметок и их количеством
+//	@Success		200 {object}    []model.NoteTypeResponse   массив с типами заметок и их количеством
+//	@Failure		204	{object}	nil "Нет заметок"
 //	@Failure		400	{object}	map[string]string "Невалидный запрос"
 //	@Failure		500	{object}	map[string]string "Внутренняя ошибка"
 //	@Router			/spaces/{id}/notes/types [get]
@@ -238,6 +239,17 @@ func (s *server) getNoteTypes(c echo.Context) error {
 	return c.JSON(http.StatusOK, types)
 }
 
+//	@Summary		Получить все заметки одного типа
+//	@Description	Получить все заметки определенного типа: текстовые, фото, етс
+//	@Param          id   path      string  true  "ID пространства"
+//	@Param          type   path      string  true  "тип заметки: текст, фото, етс"
+//	@Success		200 {object}    []model.GetNote   массив с типами заметок и их количеством
+//	@Failure		204	{object}	nil "Нет заметок"
+//	@Failure		400	{object}	map[string]string "Невалидный запрос"
+//	@Failure		500	{object}	map[string]string "Внутренняя ошибка"
+//	@Router			/spaces/{id}/notes/{type} [get]
+//
+// ручка для заметок по типу
 func (s *server) getNotesByType(c echo.Context) error {
 	spaceIDStr := c.Param("id")
 	noteType := c.Param("type")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,7 +46,8 @@ func (s *server) Serve() error {
 
 	// notes
 	spaces.GET("/:id/notes", s.notesBySpaceID)
-	spaces.GET("/:id/notes/types", s.getNoteTypes) // получить, какие есть типы заметок
+	spaces.GET("/:id/notes/types", s.getNoteTypes)   // получить, какие есть типы заметок
+	spaces.GET("/:id/notes/:type", s.getNotesByType) // получить все заметки одного типа
 	spaces.POST("/notes/create", s.createNote, s.validateNoteRequest)
 	spaces.PATCH("/notes/update", s.updateNote, s.validateNoteRequest)
 

--- a/internal/service/space/space.go
+++ b/internal/service/space/space.go
@@ -28,6 +28,8 @@ type spaceRepo interface {
 	GetNoteByID(ctx context.Context, noteID uuid.UUID) (model.GetNote, error)
 	// GetNotesTypes возвращает все типы заметок в пространстве и их количество (3 текстовых, 2 фото, и т.п.)
 	GetNotesTypes(ctx context.Context, spaceID uuid.UUID) ([]model.NoteTypeResponse, error)
+	// GetNotesByType возвращает все заметки указанного типа из пространства
+	GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType model.NoteType) ([]model.GetNote, error)
 }
 
 type spaceCache interface {
@@ -93,4 +95,9 @@ func (s *Space) IsUserInSpace(ctx context.Context, userID int64, spaceID uuid.UU
 // GetNotesTypes возвращает все типы заметок в пространстве и их количество (3 текстовых, 2 фото, и т.п.)
 func (s *Space) GetNotesTypes(ctx context.Context, spaceID uuid.UUID) ([]model.NoteTypeResponse, error) {
 	return s.repo.GetNotesTypes(ctx, spaceID)
+}
+
+// GetNotesByType возвращает все заметки указанного типа из пространства
+func (s *Space) GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType model.NoteType) ([]model.GetNote, error) {
+	return s.repo.GetNotesByType(ctx, spaceID, noteType)
 }

--- a/mocks/space_srv.go
+++ b/mocks/space_srv.go
@@ -95,6 +95,21 @@ func (mr *MockspaceRepoMockRecorder) GetNoteByID(ctx, noteID interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNoteByID", reflect.TypeOf((*MockspaceRepo)(nil).GetNoteByID), ctx, noteID)
 }
 
+// GetNotesByType mocks base method.
+func (m *MockspaceRepo) GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType model.NoteType) ([]model.GetNote, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNotesByType", ctx, spaceID, noteType)
+	ret0, _ := ret[0].([]model.GetNote)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNotesByType indicates an expected call of GetNotesByType.
+func (mr *MockspaceRepoMockRecorder) GetNotesByType(ctx, spaceID, noteType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotesByType", reflect.TypeOf((*MockspaceRepo)(nil).GetNotesByType), ctx, spaceID, noteType)
+}
+
 // GetNotesTypes mocks base method.
 func (m *MockspaceRepo) GetNotesTypes(ctx context.Context, spaceID uuid.UUID) ([]model.NoteTypeResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
получать по `spaces/:id/notes/:type` - получать заметки по типам (текстовые, фото, видео, етс)
но при этом оставить возможность получать по-старому (все заметки, без типа)

**Ошибки**
- `400` неправильный тип заметок (не "text" или "photo")
- `204` нет заметок указанного типа