### PR TITLE
Поиск заметок по тексту

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -69,6 +69,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/spaces/notes/search/text": {
+            "post": {
+                "description": "Получить все заметки с текстом среди указанного типа (по умолчанию: текстовые)",
+                "summary": "Получить все заметки по тексту",
+                "parameters": [
+                    {
+                        "description": "запрос на поиск по тексту",
+                        "name": "type",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SearchNoteByTextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GetNote"
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/spaces/notes/update": {
             "patch": {
                 "description": "Запрос на обновление заметки с текстом. Создается в указанном пространстве",
@@ -386,6 +435,21 @@ const docTemplate = `{
                 },
                 "type": {
                     "$ref": "#/definitions/model.NoteType"
+                }
+            }
+        },
+        "model.SearchNoteByTextRequest": {
+            "type": "object",
+            "properties": {
+                "space_id": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "тип заметок, для которого осуществлять поиск",
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -60,6 +60,55 @@
                 }
             }
         },
+        "/spaces/notes/search/text": {
+            "post": {
+                "description": "Получить все заметки с текстом среди указанного типа (по умолчанию: текстовые)",
+                "summary": "Получить все заметки по тексту",
+                "parameters": [
+                    {
+                        "description": "запрос на поиск по тексту",
+                        "name": "type",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SearchNoteByTextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.GetNote"
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "Нет заметок"
+                    },
+                    "400": {
+                        "description": "Невалидный запрос",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Внутренняя ошибка",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/spaces/notes/update": {
             "patch": {
                 "description": "Запрос на обновление заметки с текстом. Создается в указанном пространстве",
@@ -377,6 +426,21 @@
                 },
                 "type": {
                     "$ref": "#/definitions/model.NoteType"
+                }
+            }
+        },
+        "model.SearchNoteByTextRequest": {
+            "type": "object",
+            "properties": {
+                "space_id": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "тип заметок, для которого осуществлять поиск",
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -83,6 +83,16 @@ definitions:
       type:
         $ref: '#/definitions/model.NoteType'
     type: object
+  model.SearchNoteByTextRequest:
+    properties:
+      space_id:
+        type: string
+      text:
+        type: string
+      type:
+        description: тип заметок, для которого осуществлять поиск
+        type: string
+    type: object
   model.Space:
     properties:
       created:
@@ -284,6 +294,39 @@ paths:
               type: string
             type: object
       summary: Запрос на создание заметки
+  /spaces/notes/search/text:
+    post:
+      description: 'Получить все заметки с текстом среди указанного типа (по умолчанию:
+        текстовые)'
+      parameters:
+      - description: запрос на поиск по тексту
+        in: body
+        name: type
+        required: true
+        schema:
+          $ref: '#/definitions/model.SearchNoteByTextRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.GetNote'
+            type: array
+        "204":
+          description: Нет заметок
+        "400":
+          description: Невалидный запрос
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Внутренняя ошибка
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Получить все заметки по тексту
   /spaces/notes/update:
     patch:
       description: Запрос на обновление заметки с текстом. Создается в указанном пространстве

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.17.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
 bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -32,12 +33,15 @@ github.com/go-openapi/spec v0.21.0 h1:LTVzPc3p/RzRnkQqLRndbAzjY0d0BCL72A6j3CdL9Z
 github.com/go-openapi/spec v0.21.0/go.mod h1:78u6VdPw81XU44qEWGhtr982gJ5BWg2c0I5XwVMotYk=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -59,6 +63,7 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=

--- a/internal/errors/note.go
+++ b/internal/errors/note.go
@@ -7,4 +7,8 @@ var (
 	ErrNoteNotBelongsSpace = errors.New("note does not belong space")
 	// заметка не найдена
 	ErrNoteNotFound = errors.New("note not found")
+	// ошибка о том, что не найдены заметки указанного типа
+	ErrNoNotesFoundByType = errors.New("no notes found by this type")
+	// ошибка о том, что заметки по тексту не найдены
+	ErrNoNotesFoundByText = errors.New("no notes found by text")
 )

--- a/internal/errors/space.go
+++ b/internal/errors/space.go
@@ -11,6 +11,4 @@ var (
 	ErrSpaceNotExists = errors.New("space does not exist")
 	// ошибка о том, что пользователь не состоит в пространстве
 	ErrUserNotBelongsSpace = errors.New("user not in space")
-	// ошибка о том, что не найдены заметки указанного типа
-	ErrNoNotesFoundByType = errors.New("no notes found by this type")
 )

--- a/internal/model/elastic/note.go
+++ b/internal/model/elastic/note.go
@@ -19,6 +19,7 @@ type Note struct {
 	TgID      int64
 	Text      string
 	SpaceID   uuid.UUID
+	Type      string // тип заметки
 }
 
 // ValidateNote проверяет поля структуры elastic.Data на правильность и возвращает заметку
@@ -63,6 +64,19 @@ func (n Note) searchByTextQuery() (*search.Request, error) {
 						Match: map[string]types.MatchQuery{
 							"SpaceID": {
 								Query: n.SpaceID.String(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Bool: &types.BoolQuery{
+				Must: []types.Query{
+					{
+						Match: map[string]types.MatchQuery{
+							"Type": {
+								Query: n.Type,
 							},
 						},
 					},

--- a/internal/model/elastic/note.go
+++ b/internal/model/elastic/note.go
@@ -61,8 +61,8 @@ func (n Note) searchByTextQuery() (*search.Request, error) {
 				Must: []types.Query{
 					{
 						Match: map[string]types.MatchQuery{
-							"TgID": {
-								Query: fmt.Sprintf("%d", n.TgID),
+							"SpaceID": {
+								Query: n.SpaceID.String(),
 							},
 						},
 					},

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -194,3 +194,9 @@ type NoteTypeResponse struct {
 	Type  NoteType `json:"type"`
 	Count int      `json:"count"`
 }
+
+// запрос на поиск заметок по тексту в пространстве
+type SearchNoteByTextRequest struct {
+	SpaceID uuid.UUID `json:"space_id"`
+	Text    string    `json:"text"`
+}

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -199,4 +199,5 @@ type NoteTypeResponse struct {
 type SearchNoteByTextRequest struct {
 	SpaceID uuid.UUID `json:"space_id"`
 	Text    string    `json:"text"`
+	Type    string    `json:"type"` // тип заметок, для которого осуществлять поиск
 }

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -47,6 +47,7 @@ func runTestServer(server *server) (*echo.Echo, error) {
 	spaces.PATCH("/notes/update", server.updateNote, server.validateNoteRequest)
 	spaces.GET("/:id/notes/types", server.getNoteTypes)
 	spaces.GET("/:id/notes/:type", server.getNotesByType)
+	spaces.POST("/notes/search/text", server.searchNoteByText)
 
 	return e, nil
 }

--- a/internal/server/notes.go
+++ b/internal/server/notes.go
@@ -277,3 +277,23 @@ func (s *server) getNotesByType(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, notes)
 }
+
+func (s *server) searchNoteByText(c echo.Context) error {
+	var req model.SearchNoteByTextRequest
+
+	err := json.NewDecoder(c.Request().Body).Decode(&req)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"bad request": err.Error()})
+	}
+
+	notes, err := s.space.SearchNoteByText(c.Request().Context(), req)
+	if err != nil {
+		if errors.Is(err, api_errors.ErrNoNotesFoundByText) {
+			return c.NoContent(http.StatusNoContent)
+		}
+
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, notes)
+}

--- a/internal/server/notes.go
+++ b/internal/server/notes.go
@@ -278,12 +278,31 @@ func (s *server) getNotesByType(c echo.Context) error {
 	return c.JSON(http.StatusOK, notes)
 }
 
+//	@Summary		Получить все заметки по тексту
+//	@Description	Получить все заметки с текстом среди указанного типа (по умолчанию: текстовые)
+//	@Param          type   body      model.SearchNoteByTextRequest  true  "запрос на поиск по тексту"
+//	@Success		200 {object}    []model.GetNote   массив с типами заметок и их количеством
+//	@Failure		204	{object}	nil "Нет заметок"
+//	@Failure		400	{object}	map[string]string "Невалидный запрос"
+//	@Failure		500	{object}	map[string]string "Внутренняя ошибка"
+//	@Router			/spaces/notes/search/text [post]
+//
+// ручка для поиска заметок по тексту
 func (s *server) searchNoteByText(c echo.Context) error {
 	var req model.SearchNoteByTextRequest
 
 	err := json.NewDecoder(c.Request().Body).Decode(&req)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"bad request": err.Error()})
+	}
+
+	if len(req.Type) > 0 {
+		// валидируем запрос: тип должен быть одним из перечисленных
+		switch req.Type {
+		case string(model.TextNoteType), string(model.PhotoNoteType):
+		default:
+			return c.JSON(http.StatusBadRequest, map[string]string{"bad request": fmt.Sprintf("invalid note type: %s", req.Type)})
+		}
 	}
 
 	notes, err := s.space.SearchNoteByText(c.Request().Context(), req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,10 +46,17 @@ func (s *server) Serve() error {
 
 	// notes
 	spaces.GET("/:id/notes", s.notesBySpaceID)
-	spaces.GET("/:id/notes/types", s.getNoteTypes)   // получить, какие есть типы заметок
-	spaces.GET("/:id/notes/:type", s.getNotesByType) // получить все заметки одного типа
+
+	// создание, обновление, удаление
 	spaces.POST("/notes/create", s.createNote, s.validateNoteRequest)
 	spaces.PATCH("/notes/update", s.updateNote, s.validateNoteRequest)
+
+	// типы заметок
+	spaces.GET("/:id/notes/types", s.getNoteTypes)   // получить, какие есть типы заметок
+	spaces.GET("/:id/notes/:type", s.getNotesByType) // получить все заметки одного типа
+
+	// поиск
+	spaces.POST("/notes/search/text", s.searchNoteByText)
 
 	s.e = e
 

--- a/internal/service/space/space.go
+++ b/internal/service/space/space.go
@@ -30,6 +30,7 @@ type spaceRepo interface {
 	GetNotesTypes(ctx context.Context, spaceID uuid.UUID) ([]model.NoteTypeResponse, error)
 	// GetNotesByType возвращает все заметки указанного типа из пространства
 	GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType model.NoteType) ([]model.GetNote, error)
+	SearchNoteByText(ctx context.Context, req model.SearchNoteByTextRequest) ([]model.GetNote, error)
 }
 
 type spaceCache interface {
@@ -100,4 +101,8 @@ func (s *Space) GetNotesTypes(ctx context.Context, spaceID uuid.UUID) ([]model.N
 // GetNotesByType возвращает все заметки указанного типа из пространства
 func (s *Space) GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType model.NoteType) ([]model.GetNote, error) {
 	return s.repo.GetNotesByType(ctx, spaceID, noteType)
+}
+
+func (s *Space) SearchNoteByText(ctx context.Context, req model.SearchNoteByTextRequest) ([]model.GetNote, error) {
+	return s.repo.SearchNoteByText(ctx, req)
 }

--- a/internal/service/space/space.go
+++ b/internal/service/space/space.go
@@ -104,5 +104,9 @@ func (s *Space) GetNotesByType(ctx context.Context, spaceID uuid.UUID, noteType 
 }
 
 func (s *Space) SearchNoteByText(ctx context.Context, req model.SearchNoteByTextRequest) ([]model.GetNote, error) {
+	if len(req.Type) == 0 { // по умолчанию, если не указано, ищем среди текстовых
+		req.Type = string(model.TextNoteType)
+	}
+
 	return s.repo.SearchNoteByText(ctx, req)
 }

--- a/internal/service/storage/elasticsearch/search.go
+++ b/internal/service/storage/elasticsearch/search.go
@@ -1,0 +1,53 @@
+package elasticsearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"webserver/internal/model/elastic"
+
+	"github.com/google/uuid"
+)
+
+// Search производит поиск по переданным данным. Возвращает ID подходящих записей
+func (c *client) SearchByText(ctx context.Context, data elastic.Data) ([]uuid.UUID, error) {
+	_, err := data.ValidateNote()
+	if err != nil {
+		return nil, err
+	}
+
+	query, err := data.SearchByTextQuery()
+	if err != nil {
+		return nil, fmt.Errorf("error while creating query for search note: %+v", err)
+	}
+
+	res, err := c.cl.Search().
+		Index(data.Index.String()).
+		Request(query).Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error searching note: %+v", err)
+	}
+
+	var ids []uuid.UUID
+
+	for _, val := range res.Hits.Hits {
+		bytesJSON, err := val.Source_.MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling JSON while searching notes: %+v", err)
+		}
+
+		var note elastic.Note
+		err = json.Unmarshal(bytesJSON, &note)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling JSON while searching notes: %+v", err)
+		}
+
+		ids = append(ids, note.ID)
+	}
+
+	if len(ids) == 0 {
+		return nil, ErrRecordsNotFound
+	}
+
+	return ids, nil
+}

--- a/internal/service/storage/postgres/space/note.go
+++ b/internal/service/storage/postgres/space/note.go
@@ -10,8 +10,10 @@ import (
 	"webserver/internal/model/elastic"
 
 	api_errors "webserver/internal/errors"
+	"webserver/internal/service/storage/elasticsearch"
 
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/sirupsen/logrus"
 )
@@ -312,4 +314,57 @@ where notes.notes.space_id = $1 and type = $2;`, spaceID, noteType)
 	}
 
 	return res, nil
+}
+
+func (db *spaceRepo) SearchNoteByText(ctx context.Context, req model.SearchNoteByTextRequest) ([]model.GetNote, error) {
+	search := elastic.Data{
+		Index: elastic.NoteIndex,
+		Model: &elastic.Note{
+			SpaceID: req.SpaceID,
+			Text:    req.Text,
+		},
+	}
+
+	ids, err := db.elasticClient.SearchByText(ctx, search)
+	if err != nil {
+		if errors.Is(err, elasticsearch.ErrRecordsNotFound) {
+			return nil, api_errors.ErrNoNotesFoundByText
+		}
+
+		return nil, err
+	}
+
+	var notes []model.GetNote
+
+	q, args, err := sqlx.In(`select notes.notes.id, users.users.tg_id, text, created, last_edit, file from notes.notes
+	join users.users on users.users.id = notes.notes.user_id
+	where notes.notes.id IN(?);`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating query while searching notes: %+v", err)
+	}
+
+	q = sqlx.Rebind(sqlx.DOLLAR, q)
+	rows, err := db.db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error while searching notes by text: %w", err)
+	}
+
+	for rows.Next() {
+		note := model.GetNote{
+			SpaceID: req.SpaceID,
+		}
+
+		err := rows.Scan(&note.ID, &note.UserID, &note.Text, &note.Created, &note.LastEdit, &note.File)
+		if err != nil {
+			return nil, fmt.Errorf("error while scanning note (search by text): %w", err)
+		}
+
+		notes = append(notes, note)
+	}
+
+	if len(notes) == 0 {
+		return nil, api_errors.ErrNoNotesFoundByText
+	}
+
+	return notes, nil
 }

--- a/internal/service/storage/postgres/space/space.go
+++ b/internal/service/storage/postgres/space/space.go
@@ -74,8 +74,8 @@ func (db *spaceRepo) tx(ctx context.Context) (*sql.Tx, error) {
 	return tx, nil
 }
 
-func (db *spaceRepo) commit() error {
-	tx := db.currentTx
-	db.currentTx = nil
-	return tx.Commit()
-}
+// func (db *spaceRepo) commit() error {
+// 	tx := db.currentTx
+// 	db.currentTx = nil
+// 	return tx.Commit()
+// }

--- a/internal/service/storage/postgres/space/space.go
+++ b/internal/service/storage/postgres/space/space.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"webserver/internal/model/elastic"
 
+	"github.com/google/uuid"
 	sqldblogger "github.com/simukti/sqldb-logger"
 	"github.com/simukti/sqldb-logger/logadapter/logrusadapter"
 	"github.com/sirupsen/logrus"
@@ -21,7 +22,7 @@ type spaceRepo struct {
 type elasticClient interface {
 	Save(ctx context.Context, search elastic.Data) error
 	// SearchByText производит поиск по тексту (названию). Возвращает ID из базы подходящих записей
-	// SearchByText(ctx context.Context, search elastic.Data) ([]uuid.UUID, error)
+	SearchByText(ctx context.Context, search elastic.Data) ([]uuid.UUID, error)
 	// // SearchByID производит поиск по ID из базы. Возвращает ID  из эластика подходящих записей
 	// SearchByID(ctx context.Context, search elastic.Data) ([]string, error)
 	// Delete(ctx context.Context, search elastic.Data) error

--- a/internal/service/storage/postgres/space/space.go
+++ b/internal/service/storage/postgres/space/space.go
@@ -7,6 +7,7 @@ import (
 	"webserver/internal/model/elastic"
 
 	"github.com/google/uuid"
+	_ "github.com/lib/pq"
 	sqldblogger "github.com/simukti/sqldb-logger"
 	"github.com/simukti/sqldb-logger/logadapter/logrusadapter"
 	"github.com/sirupsen/logrus"

--- a/mocks/elastic.go
+++ b/mocks/elastic.go
@@ -10,6 +10,7 @@ import (
 	elastic "webserver/internal/model/elastic"
 
 	gomock "github.com/golang/mock/gomock"
+	uuid "github.com/google/uuid"
 )
 
 // MockelasticClient is a mock of elasticClient interface.
@@ -47,6 +48,21 @@ func (m *MockelasticClient) Save(ctx context.Context, search elastic.Data) error
 func (mr *MockelasticClientMockRecorder) Save(ctx, search interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockelasticClient)(nil).Save), ctx, search)
+}
+
+// SearchByText mocks base method.
+func (m *MockelasticClient) SearchByText(ctx context.Context, search elastic.Data) ([]uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchByText", ctx, search)
+	ret0, _ := ret[0].([]uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchByText indicates an expected call of SearchByText.
+func (mr *MockelasticClientMockRecorder) SearchByText(ctx, search interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchByText", reflect.TypeOf((*MockelasticClient)(nil).SearchByText), ctx, search)
 }
 
 // UpdateNote mocks base method.

--- a/mocks/space_srv.go
+++ b/mocks/space_srv.go
@@ -140,6 +140,21 @@ func (mr *MockspaceRepoMockRecorder) GetSpaceByID(ctx, id interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpaceByID", reflect.TypeOf((*MockspaceRepo)(nil).GetSpaceByID), ctx, id)
 }
 
+// SearchNoteByText mocks base method.
+func (m *MockspaceRepo) SearchNoteByText(ctx context.Context, req model.SearchNoteByTextRequest) ([]model.GetNote, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchNoteByText", ctx, req)
+	ret0, _ := ret[0].([]model.GetNote)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchNoteByText indicates an expected call of SearchNoteByText.
+func (mr *MockspaceRepoMockRecorder) SearchNoteByText(ctx, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchNoteByText", reflect.TypeOf((*MockspaceRepo)(nil).SearchNoteByText), ctx, req)
+}
+
 // MockspaceCache is a mock of spaceCache interface.
 type MockspaceCache struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
**Запрос**
```
URL: spaces/notes/search/text
Method: POST
Body:
{
  "space_id": "a2ea4881-bef7-473a-9081-b3df602ba481",
  "text": "search some text",
  "type": "text"
}
```

Для поиска заметок по тексту необходимо отправить запрос по адресу `/notes/search/text` методом `post`, передав в теле запроса: айди пространства, в котором нужно найти заметку; текст, который нужно найти в заметках.  Поиск доступен не только для текстовых, но и для других типов заметок - фото, видео, етс. Параметр `type` опционален - по умолчанию поиск осуществляется среди текстовых заметок.

**Ответ**
Успех: `200 ОК`
В случае успеха сервер выдаст все заметки, подходящие под запрос.

Ошибки:
- `400` неправильный тип заметок: не текст / фото
- `204` у пользователя нет заметки с таким текстом